### PR TITLE
ScrolledWindow sticking to edges

### DIFF
--- a/examples/ScrolledWindowViewport.cpp
+++ b/examples/ScrolledWindowViewport.cpp
@@ -38,6 +38,9 @@ int main() {
 	// Set the ScrolledWindow to always show the horizontal scrollbar
 	// and only show the vertical scrollbar when needed.
 	scrolledwindow->SetScrollbarPolicy( sfg::ScrolledWindow::HORIZONTAL_ALWAYS | sfg::ScrolledWindow::VERTICAL_AUTOMATIC );
+    
+    // Set sticking ON
+    scrolledwindow->SetStick(sfg::ScrolledWindow::ScrollbarSticking::YES);
 
 	// Add the ScrolledWindow box to the ScrolledWindow
 	// and create a new viewport automatically.

--- a/include/SFGUI/Adjustment.hpp
+++ b/include/SFGUI/Adjustment.hpp
@@ -25,9 +25,10 @@ class SFGUI_API Adjustment : public Object, public std::enable_shared_from_this<
 		 * @param minor_step Minor change value (such as clicking on arrow button).
 		 * @param major_step Major change value (such as clicking on the scroll area).
 		 * @param page_size Page size (how many entries are visible / slider size).
+         * @param stick True if the adjustment should stick to the maximum value.
 		 * @return Adjustment.
 		 */
-		static Ptr Create( float value = .0f, float lower = .0f, float upper = .0f, float minor_step = 1.f, float major_step = 5.f, float page_size = .0f );
+		static Ptr Create( float value = .0f, float lower = .0f, float upper = .0f, float minor_step = 1.f, float major_step = 5.f, float page_size = .0f, bool stick = false );
 
 		/** Assignment operator
 		 * @param adjustment Adjustment whose values are to be assigned to this one.
@@ -64,6 +65,21 @@ class SFGUI_API Adjustment : public Object, public std::enable_shared_from_this<
 		 * @param new_upper new maximum value
 		 */
 		void SetUpper( float new_upper );
+
+        /** Get Adjustment stick setting
+         * @return Adjustment stick setting
+         */
+        bool GetStick() const;
+
+        /** Set Adjustment stick setting
+         * @param new_stick new stick setting
+         */
+        void SetStick(bool new_stick);
+
+        /** Check if value is set to maximum
+         * @return True is Value at Upper
+         */
+        bool IsAtUpper() const;
 
 		/** Get Adjustment minor step
 		 * @return Adjustment minor step
@@ -102,8 +118,9 @@ class SFGUI_API Adjustment : public Object, public std::enable_shared_from_this<
 		 * @param new_minor_step Minor change value (such as clicking on arrow button).
 		 * @param new_major_step Major change value (such as clicking on the scroll area).
 		 * @param new_page_size Page size (how many entries are visible / slider size).
+         * @param stick True if the adjustment should stick to the maximum value.
 		 */
-		void Configure( float new_value, float new_lower, float new_upper, float new_minor_step, float new_major_step, float new_page_size );
+		void Configure( float new_value, float new_lower, float new_upper, float new_minor_step, float new_major_step, float new_page_size, bool new_stick);
 
 		/** Increment current value
 		 */
@@ -132,15 +149,17 @@ class SFGUI_API Adjustment : public Object, public std::enable_shared_from_this<
 		 * @param minor_step Minor change value (such as clicking on arrow button).
 		 * @param major_step Major change value (such as clicking on the scroll area).
 		 * @param page_size Page size (how many entries are visible / slider size).
+         * @param stick True if the adjustment should stick to the maximum value.
 		 */
-		Adjustment( float value, float lower, float upper, float minor_step, float major_step, float page_size );
+		Adjustment( float value, float lower, float upper, float minor_step, float major_step, float page_size, bool new_stick);
 
 		float m_value;
 		float m_lower;
 		float m_upper;
 		float m_minor_step;
 		float m_major_step;
-		float m_page_size;
+        float m_page_size;
+        float m_stick;
 };
 
 }

--- a/include/SFGUI/ResizableImage.hpp
+++ b/include/SFGUI/ResizableImage.hpp
@@ -189,7 +189,7 @@ namespace sfg
             if (m_KeepAspect)
             {
                 // Use same scale for both sides of the sprite
-                float lowerScale = std::min(scaleX, scaleY);
+                float lowerScale = scaleX < scaleY ? scaleX : scaleY;
 
                 tempSprite.scale(lowerScale, lowerScale);
 

--- a/include/SFGUI/ScrolledWindow.hpp
+++ b/include/SFGUI/ScrolledWindow.hpp
@@ -39,6 +39,14 @@ class SFGUI_API ScrolledWindow : public Container {
 			DEFAULT = HORIZONTAL_ALWAYS | VERTICAL_ALWAYS
 		};
 
+        /** Scrollbar sticking.
+         */
+        enum class ScrollbarSticking : char {
+            NO = 0, //!< Do not move scrollbar.
+            YES, //!< Keep scrollbar sticked to the bottom.
+            DEFAULT = NO
+        };
+
 		/** Create scrolled window.
 		 * @return ScrolledWindow.
 		 */
@@ -87,6 +95,11 @@ class SFGUI_API ScrolledWindow : public Container {
 		 * @param placement new ScrollbarPolicyPair.
 		 */
 		void SetPlacement( Placement placement );
+
+        /** Set the scrollbar behaviour when the bottom child is expanding.
+         * @param stick new ScrollbarSticking.
+         */
+        void SetStick(ScrollbarSticking stick);
 
 		/** Get the allocation of the content area of this Scrolled Window
 		 * @return Allocation of the content area of this Scrolled Window
@@ -146,7 +159,8 @@ class SFGUI_API ScrolledWindow : public Container {
 		std::shared_ptr<Viewport> m_viewport;
 
 		char m_policy;
-		Placement m_placement;
+        Placement m_placement;
+        ScrollbarSticking m_stick;
 };
 
 }

--- a/src/SFGUI/ListBox.cpp
+++ b/src/SFGUI/ListBox.cpp
@@ -543,7 +543,8 @@ void ListBox::UpdateScrollbarAdjustment() {
 		static_cast<float>( m_items.size() ),
 		1.f,
 		static_cast<float>( m_max_displayed_items_count ),
-		static_cast<float>( m_max_displayed_items_count )
+		static_cast<float>( m_max_displayed_items_count ), 
+        false // stick
 	);
 }
 

--- a/src/SFGUI/ScrolledWindow.cpp
+++ b/src/SFGUI/ScrolledWindow.cpp
@@ -14,7 +14,8 @@ ScrolledWindow::ScrolledWindow( Adjustment::Ptr horizontal_adjustment, Adjustmen
 	m_vertical_scrollbar(),
 	m_viewport(),
 	m_policy( ScrollbarPolicy::DEFAULT ),
-	m_placement( Placement::DEFAULT )
+	m_placement( Placement::DEFAULT ),
+    m_stick(ScrollbarSticking::DEFAULT)
 {
 	m_horizontal_scrollbar = Scrollbar::Create( horizontal_adjustment, Scrollbar::Orientation::HORIZONTAL );
 	m_vertical_scrollbar = Scrollbar::Create( vertical_adjustment, Scrollbar::Orientation::VERTICAL );
@@ -79,6 +80,15 @@ void ScrolledWindow::SetPlacement( Placement placement ) {
 
 	RecalculateContentAllocation();
 	Invalidate();
+}
+
+void ScrolledWindow::SetStick(ScrollbarSticking stick) {
+    m_stick = stick;
+    GetHorizontalAdjustment()->SetStick(stick == ScrollbarSticking::YES);
+    GetVerticalAdjustment()->SetStick(stick == ScrollbarSticking::YES);
+
+    RecalculateContentAllocation();
+    Invalidate();
 }
 
 bool ScrolledWindow::IsHorizontalScrollbarVisible() const {

--- a/src/SFGUI/SpinButton.cpp
+++ b/src/SFGUI/SpinButton.cpp
@@ -25,7 +25,7 @@ SpinButton::SpinButton() :
 
 SpinButton::Ptr SpinButton::Create( float minimum, float maximum, float step ) {
 	auto adjustment = Adjustment::Create();
-	adjustment->Configure( minimum, minimum, maximum, step, 0.f, 0.f );
+	adjustment->Configure( minimum, minimum, maximum, step, 0.f, 0.f, false /* stick */ );
 
 	auto ptr = Ptr( new SpinButton );
 	ptr->SetAdjustment( adjustment );


### PR DESCRIPTION
This extends ScrolledWindow adding an option for it to keep being scrolled to the end of the content. 
It is usefull when you create something like a chat and want it to keep scrolling to the end unless user changes slider.

I am currently on Windows and I had some problem compilation (or linking) with std::min in ResizableImage.
Not sure if it was something in my setup or it was not tested on Windows (however I would not expect std::min to be a problem :) ). I changed it to ternary operator to workaround the problem.